### PR TITLE
Eliminando los Shas de los certificados , si no son necesarios

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,9 +39,9 @@ android {
         buildConfigField("String", "APP_NAME", "\"CuidAR\"")
 
         // Pin certificates
-        buildConfigField("String", "CERTIFICADO_SHA1", "\"sha256/UXt/pC5LL5LT5C2ajleIfKh8FUrseWflM+tcO+284+o=\"")
-        buildConfigField("String", "CERTIFICADO_SHA2", "\"sha256/JSMzqOOrtyOT1kmau6zKhgT676hGgczD5VMdRMyJZFA=\"")
-        buildConfigField("String", "CERTIFICADO_SHA3", "\"sha256/++MBgDH5WGvL9Bcn5Be30cRcL0f5O+NyoXuWtQdX1aI=\"")
+        buildConfigField("String", "CERTIFICADO_SHA1", "\"\"")
+        buildConfigField("String", "CERTIFICADO_SHA2", "\"\"")
+        buildConfigField("String", "CERTIFICADO_SHA3", "\"\"")
     }
 
     buildTypes {

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -3,10 +3,10 @@
     <domain-config>
         <domain includeSubdomains="true">url.ar</domain>
         <pin-set>
-            <pin digest="SHA-256">UXt/pC5LL5LT5C2ajleIfKh8FUrseWflM+tcO+284+o=</pin>
+            <pin digest="SHA-256"></pin>
             <!-- backup pin -->
-            <pin digest="SHA-256">JSMzqOOrtyOT1kmau6zKhgT676hGgczD5VMdRMyJZFA=</pin>
-            <pin digest="SHA-256">++MBgDH5WGvL9Bcn5Be30cRcL0f5O+NyoXuWtQdX1aI=</pin>
+            <pin digest="SHA-256"></pin>
+            <pin digest="SHA-256"></pin>
         </pin-set>
     </domain-config>
     <domain-config cleartextTrafficPermitted="true">


### PR DESCRIPTION
Hola
Trufflehog y git-secrets reportan resultados cuando se los corre contra algunos archivos , parecen shas y nada preocupante pero si no necesitan estar ahi , se pueden usar placeholders etc.
Tambien hay un token de newrelic falso que se podria reemplazar con un placeholder